### PR TITLE
Fix build warnings and failure in test_code

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -227,6 +227,8 @@ class CodeTest(unittest.TestCase):
                         co.co_name,
                         co.co_firstlineno,
                         co.co_lnotab,
+                        co.co_enotab,
+                        co.co_cnotab,
                         co.co_exceptiontable,
                         co.co_freevars,
                         co.co_cellvars)

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -805,7 +805,7 @@ code_replace_impl(PyCodeObject *self, int co_argcount,
         co_stacksize, co_flags, (PyObject*)co_code, co_consts, co_names,
         co_varnames, co_freevars, co_cellvars, co_filename, co_name,
         co_firstlineno, (PyObject*)co_linetable, (PyObject *)co_enotab,
-        (PyObject*)co_cnotab, co_exceptiontable);
+        (PyObject*)co_cnotab, (PyObject*)co_exceptiontable);
 }
 
 static PyObject *
@@ -1469,7 +1469,7 @@ PyCode_Addr2Offset(PyCodeObject *co, int addrq)
         --addrq;
     }
 
-    int size = PyBytes_GET_SIZE(co->co_cnotab);
+    Py_ssize_t size = PyBytes_GET_SIZE(co->co_cnotab);
     if (addrq >= size) {
         return -1;
     }


### PR DESCRIPTION
Fix build warnings on windows:

```
codeobject.c(808,48): warning C4133: 'function': incompatible types - from 'PyBytesObject *' to
'PyObject  *'

codeobject.c(1472,1): warning C4244: 'initializing': conversion from 'Py_ssize_t' to 'int', possible
loss  of data

```

and a test failure in `test_code.py`:

```
test test_code failed -- Traceback (most recent call last):
  File "C:\Users\ammar\workspace\cpython\lib\test\test_code.py", line 216, in test_constructor
    return CodeType(co.co_argcount,
TypeError: code() argument 16 must be bytes, not tuple
```