### PR TITLE
Fix test failures in ctypes and test_cmd_line_script

### DIFF
--- a/Lib/ctypes/test/test_values.py
+++ b/Lib/ctypes/test/test_values.py
@@ -80,9 +80,9 @@ class PythonValuesTestCase(unittest.TestCase):
                 continue
             items.append((entry.name.decode("ascii"), entry.size))
 
-        expected = [("__hello__", 142),
-                    ("__phello__", -142),
-                    ("__phello__.spam", 142),
+        expected = [("__hello__", 168),
+                    ("__phello__", -168),
+                    ("__phello__.spam", 168),
                     ]
         self.assertEqual(items, expected, "PyImport_FrozenModules example "
             "in Doc/library/ctypes.rst may be out of date")

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -548,10 +548,10 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii').split('\n')
-            self.assertEqual(len(text), 5)
+            self.assertEqual(len(text), 6)
             self.assertTrue(text[0].startswith('Traceback'))
             self.assertTrue(text[1].startswith('  File '))
-            self.assertTrue(text[3].startswith('NameError'))
+            self.assertTrue(text[4].startswith('NameError'))
 
     def test_non_ascii(self):
         # Mac OS X denies the creation of a file with an invalid UTF-8 name.


### PR DESCRIPTION
### test_ctypes

This test needed an update, looks like it's trying to find exact offsets for symbols in frozen modules that have been moved around due to the extra data.

```
test test_ctypes failed -- Traceback (most recent call last):
  File "C:\Users\ammar\workspace\cpython\lib\ctypes\test\test_values.py", line 87, in test_frozentable
    self.assertEqual(items, expected, "PyImport_FrozenModules example "
AssertionError: Lists differ: [('__hello__', 168), ('__phello__', -168), ('__phello__.spam', 168)] != [('__hello__', 142), ('__phello__', -142), ('__phello__.spam', 142)]

First differing element 0:
('__hello__', 168)
('__hello__', 142)

- [('__hello__', 168), ('__phello__', -168), ('__phello__.spam', 168)]
?                 ^^                    ^^                        ^^

+ [('__hello__', 142), ('__phello__', -142), ('__phello__.spam', 142)]
?                 ^^                    ^^                        ^^
 : PyImport_FrozenModules example in Doc/library/ctypes.rst may be out of date
```

### test_cmd_line_script

Checks the length and output of a traceback output which now has one extra line.

```
test test_cmd_line_script failed -- Traceback (most recent call last):
  File "C:\Users\ammar\workspace\cpython\lib\test\test_cmd_line_script.py", line 551, in test_pep_409_verbiage
    self.assertEqual(len(text), 5)
AssertionError: 6 != 5
```