### PR TITLE
Return null on the error path for the iterator

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1105,7 +1105,7 @@ error:
     Py_XDECREF(end);
     Py_XDECREF(line);
     Py_XDECREF(result);
-    return result;
+    return NULL;
 }
 
 static PyTypeObject LineIterator = {


### PR DESCRIPTION
Saw some "builtin function returns value despite setting exception" errors.

As per the docs:

> When another error occurs, it must return NULL too. Its presence signals that the instances of this type are iterators.