### PR TITLE
Handle lines with multi-byte unicode characters properly

### DIFF
--- a/Include/cpython/traceback.h
+++ b/Include/cpython/traceback.h
@@ -10,5 +10,5 @@ typedef struct _traceback {
     int tb_lineno;
 } PyTracebackObject;
 
-PyAPI_FUNC(int) _Py_DisplaySourceLine(PyObject *, PyObject *, int, int, int *);
+PyAPI_FUNC(int) _Py_DisplaySourceLine(PyObject *, PyObject *, int, int, int *, PyObject **);
 PyAPI_FUNC(void) _PyTraceback_Add(const char *, const char *, int);

--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -33,9 +33,9 @@ class ExceptionTest(unittest.TestCase):
                         run.print_exception()
 
         tb = output.getvalue().strip().splitlines()
-        self.assertEqual(11, len(tb))
-        self.assertIn('UnhashableException: ex2', tb[3])
-        self.assertIn('UnhashableException: ex1', tb[10])
+        self.assertEqual(13, len(tb))
+        self.assertIn('UnhashableException: ex2', tb[4])
+        self.assertIn('UnhashableException: ex1', tb[12])
 
     data = (('1/0', ZeroDivisionError, "division by zero\n"),
             ('abc', NameError, "name 'abc' is not defined. "

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2835,6 +2835,7 @@ Check doctest with a non-ascii filename:
             exec(compile(example.source, filename, "single",
           File "<doctest foo-bär@baz[0]>", line 1, in <module>
             raise Exception('clé')
+            ^^^^^^^^^^^^^^^^^^^^^^
         Exception: clé
     TestResults(failed=1, attempted=1)
     """

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -716,7 +716,10 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
 
             s = io.StringIO()
             print_tb(tb, 1, s)
-            self.assertTrue(s.getvalue().endswith(raise_src))
+            self.assertTrue(s.getvalue().endswith(
+                '    def do_raise(): raise TypeError\n'
+                '                    ^^^^^^^^^^^^^^^\n'
+            ))
         else:
             raise AssertionError("This ought to be impossible")
 

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -543,7 +543,7 @@ show_warning(PyObject *filename, int lineno, PyObject *text,
         PyFile_WriteString("\n", f_stderr);
     }
     else {
-        _Py_DisplaySourceLine(f_stderr, filename, lineno, 2, NULL);
+        _Py_DisplaySourceLine(f_stderr, filename, lineno, 2, NULL, NULL);
     }
 
 error:

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -597,9 +597,7 @@ tb_displayline(PyTracebackObject* tb, PyObject *f, PyObject *filename, int linen
     }
     
 done:
-    if (source_line) {
-        Py_DECREF(source_line);
-    }
+    Py_XDECREF(source_line);
     return err;
 }
 
@@ -1003,4 +1001,3 @@ _Py_DumpTracebackThreads(int fd, PyInterpreterState *interp,
 
     return NULL;
 }
-


### PR DESCRIPTION
This should fix #10. To be merged after #9

It converts byte offsets to character offsets in the column numbers so that cases like

```python
raise Exception('clé')
```

are properly printed as

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    raise Exception('clé')
    ^^^^^^^^^^^^^^^^^^^^^^
Exception: clé
```

instead of

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    raise Exception('clé')
    ^^^^^^^^^^^^^^^^^^^^^^^
Exception: clé
```

This also fixes all of the remaining tests, meaning we can start building out the PEP657 tests after this.